### PR TITLE
removed (I think) unused and un-needed code

### DIFF
--- a/src/ontologies/views.py
+++ b/src/ontologies/views.py
@@ -453,10 +453,6 @@ def	write_named_entities_config():
 		# file to export all labels
 		tmplistfilename = dictionary_manager.solr_dictionary_config_path + os.path.sep + 'tmp_' + facet + '.txt'
 
-		# An empty list file for a facet won't cause error opening/reading it, even if no entry exists
-		list = open(tmplistfilename, 'a')
-		list.close()
-
 		#
 		# export entries to listfiles
 		#


### PR DESCRIPTION
It didn't seem to me that the code below does anything.

```python
# An empty list file for a facet won't cause error opening/reading it, even if no entry exists
list = open(tmplistfilename, 'a')
list.close()
```
 Is it to create the file tmplistfilename if it does not exist?
But `tmplistfilename` is set to `ontology_tagger.labels_configfile = tmplistfilename`  and then in solr_ontology_tagger when  labels_configfile is appended it is first opened:
```python
labels_file = open(self.labels_configfile, 'a', encoding="utf-8")
```

(sorry if this is an insignificant and possibly wrong pull request ... this is my first pull request ever ... I am still learning the ropes and gotta start with small steps hehe)